### PR TITLE
Fix regex validation

### DIFF
--- a/spec/outputs/firehose_spec.rb
+++ b/spec/outputs/firehose_spec.rb
@@ -8,23 +8,23 @@ require "logstash/event"
 require "aws-sdk"
 
 describe LogStash::Outputs::Firehose do
-  dataStr = "123,someValue,1234567890"
-
-  let(:sample_event) { LogStash::Event.new("message" => dataStr) }
-  let(:expected_event) { LogStash::Event.new("message" => dataStr) }
-  let(:output) { LogStash::Outputs::Firehose.new({"codec" => "plain"}) }
-
-  before do
-    Thread.abort_on_exception = true
-
-    # Setup Firehose client
-    output.stream = "aws-test-stream"
-    output.access_key_id = "Key ID"
-    output.secret_access_key = "Secret key"
-    output.register
-  end
 
   describe "receive message with plain codec" do
+    let(:data_str) { "123,someValue,1234567890" }
+    let(:sample_event) { LogStash::Event.new("message" => data_str) }
+    let(:expected_event) { LogStash::Event.new("message" => data_str) }
+    let(:output) { LogStash::Outputs::Firehose.new({"codec" => "plain", "stream" => "my-test-stream"}) }
+
+    before do
+      Thread.abort_on_exception = true
+
+      # Setup Firehose client
+      output.stream = "aws-test-stream"
+      output.access_key_id = "Key ID"
+      output.secret_access_key = "Secret key"
+      output.register
+    end
+
     subject {
       expect(output).to receive(:handle_event) do |arg|
         arg
@@ -38,4 +38,30 @@ describe LogStash::Outputs::Firehose do
       # expect(subject).to eq(expected_event["message"])
     end
   end
+
+  describe 'Configuration' do
+    let(:config) {
+      {
+        'stream' => 'my-stream',
+        'region' => 'us-west-2'
+      }
+    }
+
+    let(:bad_config) {
+      {
+        'stream' => 'good+%&]][chars'
+      }
+    }
+
+    it 'should register' do
+      output = LogStash::Plugin.lookup('output', 'firehose').new(config)
+      expect {output.register}.to_not raise_error
+    end
+
+    it 'should reject bad stream names' do
+      output = LogStash::Plugin.lookup('output', 'firehose').new(bad_config)
+      expect {output.register}.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
 end


### PR DESCRIPTION
The original regex didn't include start and end markers, so it would allow a lot of invalid stream names that included one or more valid characters. This PR adds start/end markers to the regex (the rest of the expression was copied from AWS docs, but `\w` was probably okay), and corresponding unit tests. This has some other style changes that might not be necessary.